### PR TITLE
Removed unneeded dependencies

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -2,7 +2,6 @@ PATH
   remote: .
   specs:
     validic (1.0.0)
-      activesupport
       faraday_middleware (~> 0.9.0)
       hashie (~> 2.0.3)
       multi_json
@@ -17,16 +16,11 @@ GEM
       thread_safe (~> 0.1)
       tzinfo (~> 0.3.37)
     addressable (2.3.5)
-    api_matchers (0.4.0)
-      activesupport (>= 3.2.5)
-      nokogiri (>= 1.5.2)
-      rspec (>= 2.10.0)
     atomic (1.1.14)
     coderay (1.1.0)
     crack (0.4.1)
       safe_yaml (~> 0.9.0)
     diff-lcs (1.2.5)
-    docile (1.1.2)
     dotenv (1.0.2)
     faraday (0.9.0)
       multipart-post (>= 1.2, < 3)
@@ -35,12 +29,9 @@ GEM
     hashie (2.0.5)
     i18n (0.6.9)
     method_source (0.8.2)
-    mini_portile (0.5.2)
     minitest (4.7.5)
     multi_json (1.8.4)
     multipart-post (2.0.0)
-    nokogiri (1.6.1)
-      mini_portile (~> 0.5.0)
     pry (0.10.1)
       coderay (~> 1.1.0)
       method_source (~> 0.8.1)
@@ -65,13 +56,6 @@ GEM
     shoulda-context (1.1.6)
     shoulda-matchers (2.5.0)
       activesupport (>= 3.0.0)
-    simplecov (0.8.2)
-      docile (~> 1.1.0)
-      multi_json
-      simplecov-html (~> 0.8.0)
-    simplecov-html (0.8.0)
-    simplecov-rcov (0.2.3)
-      simplecov (>= 0.4.1)
     slop (3.6.0)
     thread_safe (0.1.3)
       atomic
@@ -86,15 +70,12 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
-  api_matchers
   bundler
   dotenv
   pry
   rake
   rspec (~> 3.1.0)
   shoulda
-  simplecov
-  simplecov-rcov
   validic!
   vcr (~> 2.9.3)
   webmock (~> 1.8.0)

--- a/lib/validic/biometric.rb
+++ b/lib/validic/biometric.rb
@@ -86,7 +86,7 @@ module Validic
           uric_acid: options[:uric_acid],
           vitamin_d: options[:vitamin_d],
           white_cell_count: options[:white_cell_count],
-          timestamp: options[:timestamp] || DateTime.now.utc.to_s(:iso8601),
+          timestamp: options[:timestamp] || DateTime.now.new_offset(0).iso8601,
           utc_offset: options[:utc_offset],
           extras: options[:extras]
         }
@@ -161,7 +161,7 @@ module Validic
           uric_acid: options[:uric_acid],
           vitamin_d: options[:vitamin_d],
           white_cell_count: options[:white_cell_count],
-          timestamp: options[:timestamp] || DateTime.now.utc.to_s(:iso8601),
+          timestamp: options[:timestamp] || DateTime.now.new_offset(0).iso8601,
           utc_offset: options[:utc_offset],
           extras: options[:extras]
         }

--- a/lib/validic/diabetes.rb
+++ b/lib/validic/diabetes.rb
@@ -45,7 +45,7 @@ module Validic
         organization_id: options[:organization_id] || Validic.organization_id,
         diabetes: {
           activity_id: activity_id,
-          timestamp: options[:timestamp] || DateTime.now.utc.to_s(:iso8601),
+          timestamp: options[:timestamp] || DateTime.now.new_offset(0).iso8601,
           utc_offset: options[:utc_offset],
           c_peptide: options[:c_peptide],
           fasting_plasma_glucose_test: options[:fasting_plasma_glucose_test],
@@ -87,7 +87,7 @@ module Validic
         access_token: options[:access_token] || Validic.access_token,
         organization_id: options[:organization_id] || Validic.organization_id,
         diabetes: {
-          timestamp: options[:timestamp] || DateTime.now.utc.to_s(:iso8601),
+          timestamp: options[:timestamp] || DateTime.now.new_offset(0).iso8601,
           utc_offset: options[:utc_offset],
           c_peptide: options[:c_peptide],
           fasting_plasma_glucose_test: options[:fasting_plasma_glucose_test],

--- a/lib/validic/fitness.rb
+++ b/lib/validic/fitness.rb
@@ -45,7 +45,7 @@ module Validic
         organization_id: options[:organization_id] || Validic.organization_id,
         fitness: {
           activity_id: activity_id,
-          timestamp: options[:timestamp] || DateTime.now.utc.to_s(:iso8601),
+          timestamp: options[:timestamp] || DateTime.now.new_offset(0).iso8601,
           utc_offset: options[:utc_offset],
           type: options[:type] || 'General',
           intensity: options[:intensity],
@@ -84,7 +84,7 @@ module Validic
         organization_id: options[:organization_id] || Validic.organization_id,
         fitness: {
           activity_id: activity_id,
-          timestamp: options[:timestamp] || DateTime.now.utc.to_s(:iso8601),
+          timestamp: options[:timestamp] || DateTime.now.new_offset(0).iso8601,
           utc_offset: options[:utc_offset],
           type: options[:type] || 'General',
           intensity: options[:intensity],

--- a/lib/validic/nutrition.rb
+++ b/lib/validic/nutrition.rb
@@ -46,7 +46,7 @@ module Validic
         organization_id: options[:organization_id] || Validic.organization_id,
         nutrition: {
           entry_id: entry_id,
-          timestamp: options[:timestamp] || DateTime.now.utc.to_s(:iso8601),
+          timestamp: options[:timestamp] || DateTime.now.new_offset(0).iso8601,
           utc_offset: options[:utc_offset],
           calories: options[:calories] || 0,
           carbohydrates: options[:carbohydrates],
@@ -72,7 +72,7 @@ module Validic
         organization_id: options[:organization_id] || Validic.organization_id,
         activity_id: nutrition_id,
         nutrition: {
-          timestamp: options[:timestamp] || DateTime.now.utc.to_s(:iso8601),
+          timestamp: options[:timestamp] || DateTime.now.new_offset(0).iso8601,
           utc_offset: options[:utc_offset],
           calories: options[:calories],
           carbohydrates: options[:carbohydrates],

--- a/lib/validic/request.rb
+++ b/lib/validic/request.rb
@@ -1,5 +1,4 @@
 # encoding: utf-8
-require 'active_support/core_ext'
 require 'multi_json'
 
 module Validic

--- a/lib/validic/routine.rb
+++ b/lib/validic/routine.rb
@@ -44,7 +44,7 @@ module Validic
         organization_id: options[:organization_id] || Validic.organization_id,
         routine: {
           activity_id: activity_id,
-          timestamp: options[:timestamp] || DateTime.now.utc.to_s(:iso8601),
+          timestamp: options[:timestamp] || DateTime.now.new_offset(0).iso8601,
           utc_offset: options[:utc_offset],
           steps: options[:steps],
           distance: options[:distance],
@@ -80,7 +80,7 @@ module Validic
         access_token: options[:access_token] || Validic.access_token,
         organization_id: options[:organization_id] || Validic.organization_id,
         routine: {
-          timestamp: options[:timestamp] || DateTime.now.utc.to_s(:iso8601),
+          timestamp: options[:timestamp] || DateTime.now.new_offset(0).iso8601,
           utc_offset: options[:utc_offset],
           steps: options[:steps],
           distance: options[:distance],

--- a/lib/validic/sleep.rb
+++ b/lib/validic/sleep.rb
@@ -46,7 +46,7 @@ module Validic
         organization_id: options[:organization_id] || Validic.organization_id,
         sleep: {
           activity_id: activity_id,
-          timestamp: options[:timestamp] || DateTime.now.utc.to_s(:iso8601),
+          timestamp: options[:timestamp] || DateTime.now.new_offset(0).iso8601,
           utc_offset: options[:utc_offset],
           total_sleep: options[:total_sleep],
           awake: options[:awake],
@@ -85,7 +85,7 @@ module Validic
         access_token: options[:access_token] || Validic.access_token,
         organization_id: options[:organization_id] || Validic.organization_id,
         sleep: {
-          timestamp: options[:timestamp] || DateTime.now.utc.to_s(:iso8601),
+          timestamp: options[:timestamp] || DateTime.now.new_offset(0).iso8601,
           utc_offset: options[:utc_offset],
           total_sleep: options[:total_sleep],
           awake: options[:awake],

--- a/lib/validic/tobacco_cessation.rb
+++ b/lib/validic/tobacco_cessation.rb
@@ -42,12 +42,12 @@ module Validic
         organization_id: options[:organization_id] || Validic.organization_id,
         tobacco_cessation: {
           activity_id: activity_id,
-          timestamp: options[:timestamp] || DateTime.now.utc.to_s(:iso8601),
+          timestamp: options[:timestamp] || DateTime.now.new_offset(0).iso8601,
           utc_offset: options[:utc_offset],
           cigarettes_allowed: options[:cigarettes_allowed] || 0,
           cigarettes_smoked: options[:cigarettes_smoked] || 0,
           cravings: options[:cravings] || 0,
-          last_smoked: options[:last_smoked] || DateTime.now.utc.to_s(:iso8601),
+          last_smoked: options[:last_smoked] || DateTime.now.new_offset(0).iso8601,
           extras: options[:extras]
         }
       }
@@ -77,12 +77,12 @@ module Validic
         access_token: options[:access_token] || Validic.access_token,
         organization_id: options[:organization_id] || Validic.organization_id,
         tobacco_cessation: {
-          timestamp: options[:timestamp] || DateTime.now.utc.to_s(:iso8601),
+          timestamp: options[:timestamp] || DateTime.now.new_offset(0).iso8601,
           utc_offset: options[:utc_offset],
           cigarettes_allowed: options[:cigarettes_allowed] || 0,
           cigarettes_smoked: options[:cigarettes_smoked] || 0,
           cravings: options[:cravings] || 0,
-          last_smoked: options[:last_smoked] || DateTime.now.utc.to_s(:iso8601),
+          last_smoked: options[:last_smoked] || DateTime.now.new_offset(0).iso8601,
           extras: options[:extras]
         }
       }

--- a/lib/validic/weight.rb
+++ b/lib/validic/weight.rb
@@ -45,7 +45,7 @@ module Validic
         organization_id: options[:organization_id] || Validic.organization_id,
         weight: {
           activity_id: activity_id,
-          timestamp: options[:timestamp] || DateTime.now.utc.to_s(:iso8601),
+          timestamp: options[:timestamp] || DateTime.now.new_offset(0).iso8601,
           utc_offset: options[:utc_offset],
           weight: options[:weight] || 0,
           height: options[:height],
@@ -75,7 +75,7 @@ module Validic
         organization_id: options[:organization_id] || Validic.organization_id,
         access_token: options[:access_token] || Validic.access_token,
         weight: {
-          timestamp: options[:timestamp] || DateTime.now.utc.to_s(:iso8601),
+          timestamp: options[:timestamp] || DateTime.now.new_offset(0).iso8601,
           utc_offset: options[:utc_offset],
           weight: options[:weight] || 0,
           height: options[:height],

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,23 +1,8 @@
 require 'validic'
 require 'vcr'
-require 'simplecov'
-require 'simplecov-rcov'
-require 'api_matchers'
 require 'pry'
 require 'dotenv'
 Dotenv.load
-
-class SimpleCov::Formatter::MergedFormatter
-  def format(result)
-    SimpleCov::Formatter::HTMLFormatter.new.format(result)
-    SimpleCov::Formatter::RcovFormatter.new.format(result)
-  end
-end
-
-SimpleCov.formatter = SimpleCov::Formatter::MergedFormatter
-SimpleCov.start do
-  add_filter '/vendor'
-end
 
 VCR.configure do |c|
   c.allow_http_connections_when_no_cassette = true
@@ -34,11 +19,6 @@ VCR.configure do |c|
 end
 
 RSpec.configure do |c|
-  c.include APIMatchers::RSpecMatchers
-
-  ##
-  # Add gem specific configuration for easy access
-  #
   c.before(:each) do
     Validic.configure do |config|
       # This is using ACME Corp Credentials as per Documentation

--- a/validic.gemspec
+++ b/validic.gemspec
@@ -20,18 +20,14 @@ Gem::Specification.new do |spec|
 
   spec.add_dependency 'faraday_middleware', '~> 0.9.0'
   spec.add_dependency 'hashie', '~> 2.0.3'
-  spec.add_dependency 'activesupport'
   spec.add_dependency 'multi_json'
 
-  spec.add_development_dependency "api_matchers"
   spec.add_development_dependency "bundler"
   spec.add_development_dependency "dotenv"
   spec.add_development_dependency "pry"
   spec.add_development_dependency "rake"
   spec.add_development_dependency "rspec", '~> 3.1.0'
   spec.add_development_dependency "shoulda"
-  spec.add_development_dependency "simplecov"
-  spec.add_development_dependency "simplecov-rcov"
   spec.add_development_dependency "vcr", '~> 2.9.3'
   spec.add_development_dependency "webmock", '~> 1.8.0'
   spec.add_development_dependency "yard"


### PR DESCRIPTION
We can use ruby's built in DateTime library without the need for
ActiveSupport.
